### PR TITLE
feat: add recruitment slide builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# tuyendung
+# Trình tạo hình ảnh bài đăng tuyển dụng
+
+Ứng dụng web tĩnh giúp chọn công việc từ các tệp JSON, dựng bài tuyển dụng theo layout có sẵn và xuất thành ảnh PNG.
+
+## Cách chạy
+
+1. Cài đặt một máy chủ tĩnh (ví dụ `npm install -g serve`) hoặc sử dụng bất kỳ công cụ nào tương đương.
+2. Khởi chạy máy chủ từ thư mục dự án:
+   ```bash
+   serve .
+   ```
+3. Mở trình duyệt truy cập địa chỉ hiển thị (mặc định `http://localhost:3000`).
+
+> ⚠️ Do trình duyệt chặn việc đọc tệp `file://`, hãy chạy thông qua máy chủ tĩnh để `fetch` được dữ liệu JSON.
+
+## Cấu trúc dữ liệu
+
+- `data/jobs/index.json`: liệt kê các tệp công việc.
+- `data/jobs/*.json`: thông tin chi tiết từng vị trí (tiêu đề, mô tả, phúc lợi, liên hệ...).
+- `data/layouts.json`: cấu hình các layout (tiêu đề, tagline, nhãn phần footer...).
+
+Bạn có thể bổ sung/chỉnh sửa dữ liệu bằng cách cập nhật các tệp JSON tương ứng, giao diện sẽ hiển thị lại ngay khi tải trang.
+
+## Tính năng chính
+
+- Lựa chọn nhiều vị trí (checkbox) và layout mong muốn (radio).
+- Render nội dung tuyển dụng theo layout với phần header, phúc lợi, danh sách công việc, footer thông tin ứng tuyển.
+- Tùy chọn bật/tắt lưới canh chỉnh.
+- Xuất bản xem trước thành ảnh PNG bằng 1 click.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,405 @@
+const jobsContainer = document.getElementById('jobsContainer');
+const layoutsContainer = document.getElementById('layoutsContainer');
+const preview = document.getElementById('preview');
+const previewWrapper = document.getElementById('previewWrapper');
+const exportButton = document.getElementById('exportButton');
+const showGridToggle = document.getElementById('showGridToggle');
+const jobCardTemplate = document.getElementById('jobCardTemplate');
+
+const state = {
+  jobs: [],
+  layouts: [],
+  selectedJobs: new Set(),
+  selectedLayoutId: null,
+};
+
+async function fetchJson(path) {
+  const response = await fetch(path);
+  if (!response.ok) {
+    throw new Error(`Không thể tải dữ liệu từ ${path}`);
+  }
+  return response.json();
+}
+
+async function loadJobs() {
+  try {
+    const index = await fetchJson('data/jobs/index.json');
+    const jobs = [];
+    for (const entry of index) {
+      try {
+        const data = await fetchJson(`data/jobs/${entry.file}`);
+        const id = data.id ?? entry.id ?? entry.file.replace(/\.json$/i, '');
+        jobs.push({ ...data, id });
+      } catch (error) {
+        console.error(error);
+      }
+    }
+    state.jobs = jobs;
+    renderJobList();
+  } catch (error) {
+    jobsContainer.innerHTML = `<p class="error">${error.message}</p>`;
+  }
+}
+
+async function loadLayouts() {
+  try {
+    const layouts = await fetchJson('data/layouts.json');
+    state.layouts = layouts;
+    renderLayoutOptions();
+  } catch (error) {
+    layoutsContainer.innerHTML = `<p class="error">${error.message}</p>`;
+  }
+}
+
+function renderJobList() {
+  jobsContainer.innerHTML = '';
+
+  if (state.jobs.length === 0) {
+    jobsContainer.innerHTML = '<p class="empty">Chưa có dữ liệu công việc.</p>';
+    return;
+  }
+
+  state.jobs.forEach((job) => {
+    const label = document.createElement('label');
+    label.className = 'job-item';
+
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.value = job.id;
+    checkbox.checked = state.selectedJobs.has(job.id);
+    checkbox.addEventListener('change', () => {
+      if (checkbox.checked) {
+        state.selectedJobs.add(job.id);
+      } else {
+        state.selectedJobs.delete(job.id);
+      }
+      renderPreview();
+    });
+
+    const meta = document.createElement('div');
+    meta.className = 'job-item__meta';
+
+    const title = document.createElement('p');
+    title.className = 'job-item__title';
+    title.textContent = job.title;
+
+    const company = document.createElement('p');
+    company.className = 'job-item__company';
+    company.textContent = job.company;
+
+    const location = document.createElement('p');
+    location.className = 'job-item__location';
+    location.textContent = job.location;
+
+    meta.append(title, company, location);
+    label.append(checkbox, meta);
+    jobsContainer.append(label);
+  });
+}
+
+function renderLayoutOptions() {
+  layoutsContainer.innerHTML = '';
+
+  if (state.layouts.length === 0) {
+    layoutsContainer.innerHTML = '<p class="empty">Chưa có layout để lựa chọn.</p>';
+    return;
+  }
+
+  state.layouts.forEach((layout, index) => {
+    const label = document.createElement('label');
+    label.className = 'layout-item';
+
+    const radio = document.createElement('input');
+    radio.type = 'radio';
+    radio.name = 'layout';
+    radio.value = layout.id;
+    const shouldSelect =
+      state.selectedLayoutId === null ? index === 0 : state.selectedLayoutId === layout.id;
+    radio.checked = shouldSelect;
+
+    if (shouldSelect) {
+      state.selectedLayoutId = layout.id;
+    }
+
+    radio.addEventListener('change', () => {
+      if (radio.checked) {
+        state.selectedLayoutId = layout.id;
+        renderPreview();
+      }
+    });
+
+    const details = document.createElement('div');
+
+    const title = document.createElement('p');
+    title.className = 'layout-item__title';
+    title.textContent = layout.name;
+
+    const description = document.createElement('p');
+    description.className = 'layout-item__description';
+    description.textContent = layout.description;
+
+    const tag = document.createElement('span');
+    tag.className = 'layout-tag';
+    tag.textContent = `ID: ${layout.id}`;
+
+    details.append(title, description, tag);
+    label.append(radio, details);
+    layoutsContainer.append(label);
+  });
+
+  renderPreview();
+}
+
+function renderPreview() {
+  preview.className = 'preview';
+  preview.innerHTML = '';
+
+  const layout = state.layouts.find((item) => item.id === state.selectedLayoutId);
+  const selectedJobs = state.jobs.filter((job) => state.selectedJobs.has(job.id));
+
+  if (!layout || selectedJobs.length === 0) {
+    exportButton.disabled = true;
+    const empty = document.createElement('div');
+    empty.className = 'preview__empty';
+
+    const title = document.createElement('h3');
+    title.textContent = 'Chưa có dữ liệu để hiển thị';
+
+    const description = document.createElement('p');
+    description.textContent = 'Hãy chọn ít nhất một công việc và một layout để xem trước nội dung bài đăng.';
+
+    empty.append(title, description);
+    preview.append(empty);
+    return;
+  }
+
+  exportButton.disabled = false;
+  preview.classList.add(`preview-layout--${layout.id}`);
+
+  const primaryJob = selectedJobs[0];
+  const primaryCompany = primaryJob.company ?? layout.headerSubtitle ?? 'Doanh nghiệp';
+
+  const header = document.createElement('header');
+  header.className = 'preview__header';
+
+  const headerSubtitle = document.createElement('p');
+  headerSubtitle.className = 'preview__header-subtitle';
+  headerSubtitle.textContent = layout.headerSubtitle ?? 'Tuyển dụng';
+
+  const headerTitle = document.createElement('h1');
+  headerTitle.className = 'preview__header-title';
+  headerTitle.textContent = layout.headerTitle ?? 'We are hiring';
+
+  const headerCompany = document.createElement('p');
+  headerCompany.className = 'preview__header-company';
+  headerCompany.textContent = primaryCompany;
+
+  const tagline = document.createElement('p');
+  tagline.className = 'preview__tagline';
+  tagline.textContent = layout.tagline ?? '';
+
+  header.append(headerSubtitle, headerTitle, headerCompany);
+  if (layout.tagline) {
+    header.append(tagline);
+  }
+
+  const body = document.createElement('section');
+  body.className = 'preview__body';
+
+  const jobsWrapper = document.createElement('div');
+  jobsWrapper.className = 'preview__jobs';
+  selectedJobs.forEach((job) => {
+    jobsWrapper.append(createJobCard(job));
+  });
+
+  body.append(jobsWrapper);
+
+  const benefits = Array.from(
+    new Set(
+      selectedJobs.flatMap((job) => Array.isArray(job.benefits) ? job.benefits : [])
+    )
+  );
+  if (benefits.length > 0) {
+    const benefitsSection = document.createElement('section');
+    benefitsSection.className = 'preview__benefits';
+
+    const benefitsTitle = document.createElement('h3');
+    benefitsTitle.className = 'preview__benefits-title';
+    benefitsTitle.textContent = 'Chế độ đãi ngộ';
+
+    const benefitsList = document.createElement('ul');
+    benefitsList.className = 'preview__benefits-list';
+    benefits.forEach((benefit) => {
+      const li = document.createElement('li');
+      li.textContent = benefit;
+      benefitsList.append(li);
+    });
+
+    benefitsSection.append(benefitsTitle, benefitsList);
+    body.append(benefitsSection);
+  }
+
+  const footer = document.createElement('footer');
+  footer.className = 'preview__footer';
+
+  if (layout.tagline) {
+    const footerTagline = document.createElement('p');
+    footerTagline.textContent = layout.tagline;
+    footer.append(footerTagline);
+  }
+
+  const footerItems = document.createElement('div');
+  footerItems.className = 'preview__footer-items';
+
+  const applyItem = document.createElement('div');
+  applyItem.className = 'preview__footer-item';
+  const applyLabel = document.createElement('span');
+  applyLabel.textContent = layout.footer?.applyLabel ?? 'Nộp hồ sơ';
+  const applyContent = document.createElement('p');
+  applyContent.textContent = primaryJob.apply?.instructions ?? 'Liên hệ bộ phận nhân sự để được hướng dẫn.';
+  applyItem.append(applyLabel, applyContent);
+  if (primaryJob.apply?.deadline) {
+    const deadline = document.createElement('p');
+    deadline.innerHTML = `<strong>Hạn chót:</strong> ${primaryJob.apply.deadline}`;
+    applyItem.append(deadline);
+  }
+  if (primaryJob.apply?.applyLink) {
+    const applyLink = document.createElement('a');
+    applyLink.href = primaryJob.apply.applyLink;
+    applyLink.textContent = 'Link ứng tuyển';
+    applyLink.target = '_blank';
+    applyLink.rel = 'noopener noreferrer';
+    applyItem.append(applyLink);
+  }
+
+  const interviewItem = document.createElement('div');
+  interviewItem.className = 'preview__footer-item';
+  const interviewLabel = document.createElement('span');
+  interviewLabel.textContent = layout.footer?.interviewLabel ?? 'Địa điểm phỏng vấn';
+  const interviewContent = document.createElement('p');
+  interviewContent.textContent = primaryJob.interviewAddress ?? 'Sẽ thông báo sau khi đạt phỏng vấn.';
+  interviewItem.append(interviewLabel, interviewContent);
+
+  const contactItem = document.createElement('div');
+  contactItem.className = 'preview__footer-item';
+  const contactLabel = document.createElement('span');
+  contactLabel.textContent = layout.footer?.contactLabel ?? 'Liên hệ';
+  const contactContent = document.createElement('p');
+  const applyDeadline = primaryJob.apply?.deadline;
+  const contactPhone = primaryJob.contactPhone ?? '---';
+  contactContent.textContent = applyDeadline
+    ? `${contactPhone} • Hạn chót: ${applyDeadline}`
+    : contactPhone;
+  contactItem.append(contactLabel, contactContent);
+
+  footerItems.append(applyItem, interviewItem, contactItem);
+  footer.append(footerItems);
+
+  preview.append(header, body, footer);
+}
+
+function createJobCard(job) {
+  const fragment = jobCardTemplate.content.cloneNode(true);
+  const title = fragment.querySelector('.job-card__title');
+  const department = fragment.querySelector('.job-card__department');
+  const location = fragment.querySelector('.job-card__location');
+  const descriptionList = fragment.querySelector('.job-card__description');
+  const requirementsList = fragment.querySelector('.job-card__requirements');
+
+  title.textContent = job.title;
+  if (job.department) {
+    department.textContent = job.department;
+  } else {
+    department.remove();
+  }
+
+  if (job.location) {
+    location.textContent = job.location;
+  } else {
+    location.remove();
+  }
+
+  fillList(descriptionList, job.description);
+  fillList(requirementsList, job.requirements);
+
+  return fragment;
+}
+
+function fillList(listElement, items) {
+  listElement.innerHTML = '';
+  if (!Array.isArray(items) || items.length === 0) {
+    const empty = document.createElement('li');
+    empty.textContent = 'Đang cập nhật.';
+    listElement.append(empty);
+    return;
+  }
+
+  items.forEach((item) => {
+    const li = document.createElement('li');
+    li.textContent = item;
+    listElement.append(li);
+  });
+}
+
+async function handleExport() {
+  exportButton.disabled = true;
+  exportButton.textContent = 'Đang xuất...';
+  try {
+    const canvas = await html2canvas(preview, {
+      backgroundColor: '#ffffff',
+      scale: window.devicePixelRatio < 2 ? 2 : window.devicePixelRatio,
+    });
+    const blob = await canvasToBlob(canvas);
+    const layout = state.layouts.find((item) => item.id === state.selectedLayoutId);
+    const company = state.jobs.find((job) => state.selectedJobs.has(job.id))?.company ?? 'tuyendung';
+    const filename = `${slugify(company)}-${layout?.id ?? 'layout'}-${new Date()
+      .toISOString()
+      .slice(0, 10)}.png`;
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    link.click();
+    URL.revokeObjectURL(link.href);
+  } catch (error) {
+    alert(error.message);
+  } finally {
+    exportButton.disabled = false;
+    exportButton.textContent = 'Xuất hình ảnh';
+  }
+}
+
+function canvasToBlob(canvas) {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error('Không thể tạo hình ảnh.'));
+        }
+      },
+      'image/png',
+      1
+    );
+  });
+}
+
+function slugify(text) {
+  return text
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .replace(/\s+/g, '-');
+}
+
+showGridToggle.addEventListener('change', () => {
+  previewWrapper.classList.toggle('hide-grid', !showGridToggle.checked);
+});
+
+previewWrapper.classList.toggle('hide-grid', !showGridToggle.checked);
+
+exportButton.addEventListener('click', handleExport);
+
+loadJobs();
+loadLayouts();

--- a/data/jobs/frontend-engineer.json
+++ b/data/jobs/frontend-engineer.json
@@ -1,0 +1,31 @@
+{
+  "id": "frontend-engineer",
+  "title": "Frontend Engineer",
+  "department": "Sản phẩm & Công nghệ",
+  "company": "Công ty CP Công nghệ FutureWorks",
+  "location": "Hà Nội hoặc làm việc từ xa",
+  "interviewAddress": "Tầng 12, Toà nhà Innovation, 36 Hoàng Cầu, Đống Đa, Hà Nội",
+  "contactPhone": "0981 123 456",
+  "apply": {
+    "instructions": "Gửi CV về hr@futureworks.vn với tiêu đề: [FW_FE]_Họ tên",
+    "deadline": "30/05/2024",
+    "applyLink": "https://futureworks.vn/careers/frontend-engineer"
+  },
+  "benefits": [
+    "Thu nhập cạnh tranh 18-30 triệu + thưởng hiệu suất",
+    "Hybrid 3-2, trợ cấp làm việc từ xa",
+    "Gói bảo hiểm sức khoẻ nâng cao cho bản thân và gia đình",
+    "Ngân sách học tập 12.000.000đ/năm"
+  ],
+  "description": [
+    "Phối hợp với UX/UI Designer để xây dựng giao diện sản phẩm FutureWorks",
+    "Tối ưu hiệu năng, trải nghiệm và accessibility cho người dùng cuối",
+    "Tham gia xây dựng design system nội bộ"
+  ],
+  "requirements": [
+    "Tối thiểu 2 năm kinh nghiệm với React hoặc Vue",
+    "Hiểu biết vững chắc về HTML5, CSS3 và ES6",
+    "Có kinh nghiệm với hệ thống thiết kế, TypeScript là lợi thế",
+    "Khả năng giao tiếp và phối hợp nhóm tốt"
+  ]
+}

--- a/data/jobs/hr-generalist.json
+++ b/data/jobs/hr-generalist.json
@@ -1,0 +1,31 @@
+{
+  "id": "hr-generalist",
+  "title": "HR Generalist",
+  "department": "Phòng Nhân sự",
+  "company": "Công ty CP Công nghệ FutureWorks",
+  "location": "TP. Hồ Chí Minh",
+  "interviewAddress": "Lầu 5, Toà nhà Centric, 1 Nguyễn Huệ, Quận 1, TP. HCM",
+  "contactPhone": "0938 456 789",
+  "apply": {
+    "instructions": "Gửi CV về hr@futureworks.vn với tiêu đề: [FW_HR]_Họ tên",
+    "deadline": "15/06/2024",
+    "applyLink": "https://futureworks.vn/careers/hr-generalist"
+  },
+  "benefits": [
+    "Lương 16-22 triệu tuỳ kinh nghiệm",
+    "Thưởng quý theo kết quả OKR",
+    "12 ngày phép/năm + 5 ngày recharge",
+    "Được tham gia xây dựng văn hoá doanh nghiệp"
+  ],
+  "description": [
+    "Triển khai quy trình tuyển dụng, onboarding",
+    "Theo dõi chính sách phúc lợi, hợp đồng lao động",
+    "Đồng hành cùng các trưởng bộ phận trong xây dựng lộ trình phát triển nhân sự"
+  ],
+  "requirements": [
+    "Tối thiểu 2 năm kinh nghiệm ở vị trí tương đương",
+    "Nắm rõ luật lao động Việt Nam",
+    "Kỹ năng giao tiếp, thuyết phục và giải quyết vấn đề tốt",
+    "Ưu tiên ứng viên có chứng chỉ HRBP"
+  ]
+}

--- a/data/jobs/index.json
+++ b/data/jobs/index.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "frontend-engineer",
+    "file": "frontend-engineer.json"
+  },
+  {
+    "id": "hr-generalist",
+    "file": "hr-generalist.json"
+  },
+  {
+    "id": "sales-executive",
+    "file": "sales-executive.json"
+  }
+]

--- a/data/jobs/sales-executive.json
+++ b/data/jobs/sales-executive.json
@@ -1,0 +1,31 @@
+{
+  "id": "sales-executive",
+  "title": "Sales Executive",
+  "department": "Khối Kinh doanh",
+  "company": "Công ty CP Công nghệ FutureWorks",
+  "location": "Đà Nẵng",
+  "interviewAddress": "Tầng 8, 78 Bạch Đằng, Hải Châu, Đà Nẵng",
+  "contactPhone": "0976 888 999",
+  "apply": {
+    "instructions": "Gửi CV về sales@futureworks.vn hoặc điền form online",
+    "deadline": "30/06/2024",
+    "applyLink": "https://futureworks.vn/careers/sales-executive"
+  },
+  "benefits": [
+    "Thu nhập 12-18 triệu + hoa hồng theo doanh số",
+    "Thưởng nóng khi đạt deal lớn",
+    "Đào tạo kỹ năng bán hàng, giao tiếp",
+    "Du lịch thường niên trong và ngoài nước"
+  ],
+  "description": [
+    "Tìm kiếm, phát triển khách hàng doanh nghiệp",
+    "Tư vấn giải pháp phần mềm FutureWorks cho khách hàng",
+    "Phối hợp cùng đội ngũ Delivery đảm bảo tiến độ triển khai"
+  ],
+  "requirements": [
+    "Kinh nghiệm 1-2 năm trong mảng B2B là lợi thế",
+    "Kỹ năng giao tiếp và trình bày tự tin",
+    "Chủ động, chịu được áp lực doanh số",
+    "Sẵn sàng di chuyển gặp gỡ khách hàng"
+  ]
+}

--- a/data/layouts.json
+++ b/data/layouts.json
@@ -1,0 +1,28 @@
+[
+  {
+    "id": "modern",
+    "name": "Gradient hiện đại",
+    "description": "Phong cách tươi trẻ với mảng màu chuyển sắc, phù hợp công ty công nghệ.",
+    "headerTitle": "We're Hiring",
+    "headerSubtitle": "Gia nhập FutureWorks",
+    "tagline": "Cơ hội bứt phá sự nghiệp cùng đội ngũ giàu nhiệt huyết",
+    "footer": {
+      "applyLabel": "Nộp hồ sơ",
+      "interviewLabel": "Địa điểm phỏng vấn",
+      "contactLabel": "Liên hệ tư vấn"
+    }
+  },
+  {
+    "id": "minimal",
+    "name": "Tối giản sang trọng",
+    "description": "Tông màu trầm, tập trung vào nội dung, phù hợp doanh nghiệp dịch vụ chuyên nghiệp.",
+    "headerTitle": "Tuyển dụng",
+    "headerSubtitle": "Tìm kiếm đồng đội mới",
+    "tagline": "Môi trường linh hoạt - Chế độ hấp dẫn - Lộ trình rõ ràng",
+    "footer": {
+      "applyLabel": "Cách nộp hồ sơ",
+      "interviewLabel": "Địa chỉ phỏng vấn",
+      "contactLabel": "Hotline"
+    }
+  }
+]

--- a/index.html
+++ b/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="vi">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Trình tạo slide tuyển dụng</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Be+Vietnam+Pro:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="brand">
+        <h1>Trình tạo bài đăng tuyển dụng</h1>
+        <p>Chọn công việc, chọn layout và xuất thành ảnh trong vài bước.</p>
+      </div>
+      <button id="exportButton" class="button button-primary" disabled>
+        Xuất hình ảnh
+      </button>
+    </header>
+    <main class="app">
+      <section class="panel" aria-labelledby="jobs-title">
+        <h2 id="jobs-title">Chọn công việc</h2>
+        <p class="panel-description">
+          Dữ liệu được lấy từ các tệp JSON trong thư mục <code>data/jobs</code>.
+        </p>
+        <div id="jobsContainer" class="jobs"></div>
+      </section>
+      <section class="panel" aria-labelledby="layouts-title">
+        <h2 id="layouts-title">Chọn layout</h2>
+        <div id="layoutsContainer" class="layouts"></div>
+      </section>
+      <section class="panel panel-preview" aria-labelledby="preview-title">
+        <div class="preview-header">
+          <h2 id="preview-title">Xem trước</h2>
+          <label class="toggle">
+            <input type="checkbox" id="showGridToggle" checked />
+            <span>Hiện lưới canh chỉnh</span>
+          </label>
+        </div>
+        <div id="previewWrapper" class="preview-wrapper">
+          <div id="preview" class="preview" role="img" aria-label="Bản xem trước bài đăng tuyển dụng"></div>
+        </div>
+      </section>
+    </main>
+    <template id="jobCardTemplate">
+      <article class="job-card">
+        <header class="job-card__header">
+          <h3 class="job-card__title"></h3>
+          <p class="job-card__department"></p>
+          <p class="job-card__location"></p>
+        </header>
+        <div class="job-card__body">
+          <section class="job-card__section">
+            <h4>Mô tả công việc</h4>
+            <ul class="job-card__description"></ul>
+          </section>
+          <section class="job-card__section">
+            <h4>Yêu cầu</h4>
+            <ul class="job-card__requirements"></ul>
+          </section>
+        </div>
+      </article>
+    </template>
+    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js" integrity="sha256-vo4a9PXgC7cmkQC9h5pz50jdK4Zk90un0nLBKBPXn2I=" crossorigin="anonymous"></script>
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,444 @@
+:root {
+  color-scheme: light;
+  font-family: 'Be Vietnam Pro', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+  --color-background: #f5f7fb;
+  --color-surface: #ffffff;
+  --color-border: #d9deeb;
+  --color-primary: #1e4dd8;
+  --color-primary-dark: #173aa6;
+  --color-text: #17203f;
+  --color-muted: #5b6380;
+  --shadow-lg: 0 20px 60px rgba(23, 32, 63, 0.1);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--color-background);
+  color: var(--color-text);
+}
+
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2rem clamp(1.5rem, 3vw, 3rem);
+  gap: 1rem;
+}
+
+.app-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+}
+
+.app-header p {
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 1rem;
+  transition: transform 0.15s ease, box-shadow 0.15s ease,
+    background 0.15s ease;
+}
+
+.button-primary {
+  background: var(--color-primary);
+  color: white;
+  box-shadow: 0 15px 35px rgba(30, 77, 216, 0.35);
+}
+
+.button-primary:disabled {
+  cursor: not-allowed;
+  filter: grayscale(0.4);
+  box-shadow: none;
+}
+
+.button-primary:not(:disabled):hover {
+  transform: translateY(-1px);
+  background: var(--color-primary-dark);
+}
+
+.app {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+  padding: 0 1.5rem 2rem;
+}
+
+.panel {
+  background: var(--color-surface);
+  border-radius: 24px;
+  padding: 1.75rem;
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.panel h2 {
+  margin: 0;
+}
+
+.panel-description {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.95rem;
+}
+
+.jobs,
+.layouts {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.job-item,
+.layout-item {
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  padding: 1rem;
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.job-item:hover,
+.layout-item:hover {
+  border-color: var(--color-primary);
+  box-shadow: 0 12px 30px rgba(23, 32, 63, 0.08);
+}
+
+.job-item input,
+.layout-item input {
+  margin-top: 0.25rem;
+}
+
+.job-item__meta {
+  flex: 1;
+}
+
+.job-item__title {
+  font-weight: 600;
+  margin: 0 0 0.35rem;
+}
+
+.job-item__company,
+.job-item__location {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.layout-item__title {
+  margin: 0 0 0.35rem;
+  font-weight: 600;
+}
+
+.layout-item__description {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.panel-preview {
+  grid-column: 1 / -1;
+}
+
+.preview-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.preview-wrapper {
+  position: relative;
+  background: repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 24px,
+      rgba(30, 77, 216, 0.1) 24px,
+      rgba(30, 77, 216, 0.1) 25px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      transparent,
+      transparent 24px,
+      rgba(30, 77, 216, 0.1) 24px,
+      rgba(30, 77, 216, 0.1) 25px
+    );
+  padding: 1rem;
+  border-radius: 20px;
+}
+
+.preview-wrapper.hide-grid {
+  background: none;
+}
+
+.preview {
+  width: 1080px;
+  height: 1350px;
+  margin: 0 auto;
+  background: white;
+  border-radius: 32px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.preview__header {
+  padding: 2.5rem 3rem 1.5rem;
+  color: white;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.preview__header-logo {
+  width: 120px;
+}
+
+.preview__header-title {
+  margin: 0;
+  font-size: 2.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.preview__header-subtitle {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+}
+
+.preview__header-company {
+  margin: 0;
+  font-size: 1.3rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.preview__tagline {
+  margin: 0;
+  font-size: 1.1rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.preview__body {
+  flex: 1;
+  padding: 2rem 3rem 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.preview__jobs {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.preview__benefits {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.preview__benefits-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-primary-dark);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.preview__benefits-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+}
+
+.preview__footer {
+  background: rgba(0, 0, 0, 0.04);
+  padding: 1.5rem 3rem;
+  display: grid;
+  gap: 0.5rem;
+  font-size: 1rem;
+}
+
+.preview__footer strong {
+  color: var(--color-primary-dark);
+}
+
+.preview__footer-items {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.preview__footer-item {
+  background: white;
+  border-radius: 16px;
+  padding: 1rem 1.25rem;
+  border: 1px solid rgba(23, 32, 63, 0.08);
+  box-shadow: 0 10px 24px rgba(23, 32, 63, 0.08);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.preview__footer-item span {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  font-weight: 600;
+}
+
+.preview__footer-item p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.45;
+  color: var(--color-text);
+  word-break: break-word;
+}
+
+.preview__footer-item p strong {
+  color: var(--color-primary-dark);
+}
+
+.preview__footer-item a {
+  color: var(--color-primary);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.preview__footer-item a:hover {
+  text-decoration: underline;
+}
+
+.preview__empty {
+  margin: auto;
+  text-align: center;
+  max-width: 360px;
+  display: grid;
+  gap: 0.75rem;
+  color: var(--color-muted);
+}
+
+.preview__empty h3 {
+  margin: 0;
+  font-size: 1.35rem;
+  color: var(--color-text);
+}
+
+.job-card {
+  border-radius: 20px;
+  padding: 1.5rem;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(23, 32, 63, 0.07);
+  box-shadow: 0 15px 40px rgba(23, 32, 63, 0.08);
+  display: grid;
+  gap: 1rem;
+}
+
+.job-card__header h3 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.job-card__department {
+  margin: 0.35rem 0 0;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.job-card__location {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: var(--color-primary-dark);
+  font-weight: 500;
+}
+
+.job-card__section h4 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-primary-dark);
+}
+
+.job-card__section ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.preview-layout--modern .preview__header {
+  background: linear-gradient(135deg, #1e4dd8, #5f7cff);
+}
+
+.preview-layout--minimal .preview__header {
+  background: linear-gradient(120deg, #0f172a, #334155);
+}
+
+.preview-layout--minimal .preview__body {
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.04), transparent);
+}
+
+.layout-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  background: rgba(30, 77, 216, 0.12);
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+}
+
+.toggle input {
+  accent-color: var(--color-primary);
+}
+
+.empty,
+.error {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-muted);
+}
+
+.error {
+  color: #d81e5b;
+}
+
+@media (max-width: 1180px) {
+  .preview {
+    width: min(100%, 720px);
+    height: auto;
+    aspect-ratio: 4 / 5;
+  }
+}


### PR DESCRIPTION
## Summary
- build a static recruitment post builder interface with job and layout selectors
- add preview styling including job cards, benefits, and footer info blocks
- seed sample job and layout JSON data to drive the UI

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68dff05373708320973ce983a9a3e7ba